### PR TITLE
kafl-agent: Fix fuzzing dump of __user pointers

### DIFF
--- a/arch/x86/kernel/kafl-agent.c
+++ b/arch/x86/kernel/kafl-agent.c
@@ -506,7 +506,12 @@ size_t kafl_fuzz_buffer(void* fuzz_buf, const void *orig_buf,
 
 		memcpy(ob_buf + ob_pos, fuzz_buf, num_fuzzed);
 		ob_pos += num_fuzzed;
-		memcpy(ob_buf + ob_pos, orig_buf, num_bytes-num_fuzzed);
+		// Avoid KASAN warnings on user memory access
+		if (access_ok(orig_buf, num_bytes-num_fuzzed)) {
+			copy_from_user(ob_buf + ob_pos, orig_buf, num_bytes-num_fuzzed);
+		} else {
+			memcpy(ob_buf + ob_pos, orig_buf, num_bytes-num_fuzzed);
+		}
 		ob_pos += (num_bytes-num_fuzzed);
 	}
 


### PR DESCRIPTION
KASAN threw an error on accessing user pointers when fuzzing. This patch
now distinguishes between kernel pointers and user pointers to avoid
false positive KASAN triggers.

This pull request is for the kafl/fuzz-5.15-4 branch. See https://github.com/IntelLabs/kafl.linux/pull/2 for the 5.15-3 branch.